### PR TITLE
Implement cookie allocator to mark flow by cookie id

### DIFF
--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -16,11 +16,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
 	"io/ioutil"
 	"net"
 
 	"github.com/vmware-tanzu/antrea/pkg/cni"
+	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
 
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v2"

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -216,7 +216,7 @@ func (i *Initializer) Initialize() error {
 // initOpenFlowPipeline sets up necessary Openflow entries, including pipeline, classifiers, conn_track, and gateway flows
 func (i *Initializer) initOpenFlowPipeline() error {
 	// Setup all basic flows.
-	if err := i.ofClient.Initialize(); err != nil {
+	if err := i.ofClient.Initialize(i.ovsBridgeClient); err != nil {
 		klog.Errorf("Failed to setup basic openflow entries: %v", err)
 		return err
 	}

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -200,7 +200,8 @@ func (c *client) InstallGatewayFlows(gatewayAddr net.IP, gatewayMAC net.Hardware
 func (c *client) InstallTunnelFlows(tunnelOFPort uint32) error {
 	if err := c.flowOperations.Add(c.tunnelClassifierFlow(tunnelOFPort, cookie.Default)); err != nil {
 		return err
-	} else if err := c.flowOperations.Add(c.l2ForwardCalcFlow(globalVirtualMAC, tunnelOFPort, 0)); err != nil {
+	}
+	if err := c.flowOperations.Add(c.l2ForwardCalcFlow(globalVirtualMAC, tunnelOFPort, 0)); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/agent/openflow/cookie/allocator.go
+++ b/pkg/agent/openflow/cookie/allocator.go
@@ -1,0 +1,118 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cookie
+
+import (
+	"fmt"
+)
+
+const (
+	BitwidthRound    = 16
+	BitwidthCategory = 8
+	BitwidthReserved = 64 - BitwidthCategory - BitwidthRound
+)
+
+// Category represents the flow entry category.
+type Category uint64
+
+const (
+	Default Category = iota
+	Gateway
+	Node
+	Pod
+	Service
+	Policy
+)
+
+func (c Category) String() string {
+	switch c {
+	case Default:
+		return "Default"
+	case Gateway:
+		return "Gateway"
+	case Node:
+		return "Node"
+	case Pod:
+		return "Pod"
+	case Service:
+		return "Service"
+	case Policy:
+		return "Policy"
+	default:
+		return "Invalid"
+	}
+}
+
+// ID defines segments a cookie ID contains. An ID is composed like:
+//
+// |------------------------- ID --------------------------|
+//
+// |- round 16bits -|- category 8bits -|- reserved 40bits -|
+// The round segment represents the round id.
+// The category segment represents the category of flow this ID belongs.
+
+type ID uint64
+
+func newID(round uint64, cat Category) ID {
+	r := uint64(0)
+	r |= round << (64 - BitwidthRound)
+	r |= (uint64(cat) << (BitwidthReserved + BitwidthRound)) >> (BitwidthRound)
+	return ID(r)
+}
+
+// Raw returns the unit64 type value of the ID
+func (i ID) Raw() uint64 {
+	return uint64(i)
+}
+
+// Round returns the round number of the ID
+func (i ID) Round() uint64 {
+	return uint64(i) >> (64 - BitwidthRound)
+}
+
+// Category returns the category of the ID
+func (i ID) Category() Category {
+	return Category((uint64(i) << BitwidthRound) >> (64 - BitwidthCategory))
+}
+
+// Category returns the string representation of the ID
+func (i ID) String() string {
+	return fmt.Sprintf("<round:%d,category:%s>", i.Round(), i.Category().String())
+}
+
+// Allocator defines operations of a cookie ID allocator.
+type Allocator interface {
+	// Request cookie IDs of flow categories.
+	Request(cat Category) ID
+}
+
+type allocator struct {
+	round uint64
+}
+
+// Mask returns a ID with the given category.
+func (a *allocator) Request(cat Category) ID {
+	return newID(a.round, cat)
+}
+
+// Mask returns a mask to match specific category of flows.
+func (a *allocator) Mask(cat Category) uint64 {
+	return newID(a.round, cat).Raw()
+}
+
+// NewAllocator creates a cookie ID allocator by using the given round number. Only last 16 bits of the round number would be used.
+func NewAllocator(round uint64) Allocator {
+	return &allocator{round: round}
+}

--- a/pkg/agent/openflow/cookie/allocator.go
+++ b/pkg/agent/openflow/cookie/allocator.go
@@ -56,13 +56,10 @@ func (c Category) String() string {
 }
 
 // ID defines segments a cookie ID contains. An ID is composed like:
-//
-// |------------------------- ID --------------------------|
-//
-// |- round 16bits -|- category 8bits -|- reserved 40bits -|
+//  |------------------------- ID --------------------------|
+//  |- round 16bits -|- category 8bits -|- reserved 40bits -|
 // The round segment represents the round id.
 // The category segment represents the category of flow this ID belongs.
-
 type ID uint64
 
 func newID(round uint64, cat Category) ID {
@@ -72,22 +69,22 @@ func newID(round uint64, cat Category) ID {
 	return ID(r)
 }
 
-// Raw returns the unit64 type value of the ID
+// Raw returns the unit64 type value of the ID.
 func (i ID) Raw() uint64 {
 	return uint64(i)
 }
 
-// Round returns the round number of the ID
+// Round returns the round number of the ID.
 func (i ID) Round() uint64 {
 	return uint64(i) >> (64 - BitwidthRound)
 }
 
-// Category returns the category of the ID
+// Category returns the category of the ID.
 func (i ID) Category() Category {
 	return Category((uint64(i) << BitwidthRound) >> (64 - BitwidthCategory))
 }
 
-// Category returns the string representation of the ID
+// String returns the string representation of the ID.
 func (i ID) String() string {
 	return fmt.Sprintf("<round:%d,category:%s>", i.Round(), i.Category().String())
 }
@@ -102,14 +99,9 @@ type allocator struct {
 	round uint64
 }
 
-// Mask returns a ID with the given category.
+// Request returns a ID with the given category.
 func (a *allocator) Request(cat Category) ID {
 	return newID(a.round, cat)
-}
-
-// Mask returns a mask to match specific category of flows.
-func (a *allocator) Mask(cat Category) uint64 {
-	return newID(a.round, cat).Raw()
 }
 
 // NewAllocator creates a cookie ID allocator by using the given round number. Only last 16 bits of the round number would be used.

--- a/pkg/agent/openflow/cookie/allocator_test.go
+++ b/pkg/agent/openflow/cookie/allocator_test.go
@@ -1,0 +1,75 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cookie
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var result ID // Ensures that the call to Request is not optimized-out by the compiler.
+
+func BenchmarkIDAllocate(b *testing.B) {
+	a := NewAllocator(0)
+	for i := 0; i < b.N; i++ {
+		result = a.Request(Default)
+	}
+}
+
+// TestConcurrentAllocate spawns multiple goroutines to ensure that the allocator is thread-safe.
+func TestConcurrentAllocate(t *testing.T) {
+	eachTotal := 10000
+	concurrentNum := 8
+
+	rand.Seed(time.Now().UnixNano())
+	round := rand.Uint64() >> (64 - BitwidthRound)
+	a := NewAllocator(round)
+
+	eachGoroutine := func() {
+		var seq []Category
+
+		for i := 0; i < eachTotal; i++ {
+			seq = append(seq, Pod, Node, Default)
+		}
+		rand.Shuffle(len(seq), func(a, b int) { seq[a], seq[b] = seq[b], seq[a] })
+
+		for i := 0; i < eachTotal/2; i++ {
+			id := a.Request(seq[i])
+			assert.Equal(t, round, id.Round(), id.String())
+			assert.Equal(t, seq[i].String(), id.Category().String(), id.String())
+		}
+
+		for i := 0; i < eachTotal; i++ {
+			id := a.Request(seq[i])
+			assert.Equal(t, round, id.Round(), id.String())
+			assert.Equal(t, seq[i].String(), id.Category().String(), id.String())
+		}
+
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < concurrentNum; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			eachGoroutine()
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/agent/openflow/cookie/doc.go
+++ b/pkg/agent/openflow/cookie/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cookie implements a cookie allocator.
+// The allocated cookies are used to classify flows in the vSwitch, which simplifies management of these flows.
+package cookie

--- a/pkg/agent/openflow/network_policy_test.go
+++ b/pkg/agent/openflow/network_policy_test.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/vmware-tanzu/antrea/pkg/agent/openflow/cookie"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -235,6 +237,7 @@ func expectConjunctionsCount(conjs []*expectConjunctionTimes) {
 
 func newMockDropFlowBuilder(ctrl *gomock.Controller) *mocks.MockFlowBuilder {
 	dropFlowBuilder = mocks.NewMockFlowBuilder(ctrl)
+	dropFlowBuilder.EXPECT().Cookie(gomock.Any()).Return(dropFlowBuilder).AnyTimes()
 	dropFlowBuilder.EXPECT().MatchProtocol(gomock.Any()).Return(dropFlowBuilder).AnyTimes()
 	dropFlowBuilder.EXPECT().MatchDstIPNet(gomock.Any()).Return(dropFlowBuilder).AnyTimes()
 	dropFlowBuilder.EXPECT().MatchSrcIPNet(gomock.Any()).Return(dropFlowBuilder).AnyTimes()
@@ -252,6 +255,7 @@ func newMockDropFlowBuilder(ctrl *gomock.Controller) *mocks.MockFlowBuilder {
 
 func newMockRuleFlowBuilder(ctrl *gomock.Controller) *mocks.MockFlowBuilder {
 	ruleFlowBuilder = mocks.NewMockFlowBuilder(ctrl)
+	ruleFlowBuilder.EXPECT().Cookie(gomock.Any()).Return(ruleFlowBuilder).AnyTimes()
 	ruleFlowBuilder.EXPECT().MatchProtocol(gomock.Any()).Return(ruleFlowBuilder).AnyTimes()
 	ruleFlowBuilder.EXPECT().MatchDstIPNet(gomock.Any()).Return(ruleFlowBuilder).AnyTimes()
 	ruleFlowBuilder.EXPECT().MatchSrcIPNet(gomock.Any()).Return(ruleFlowBuilder).AnyTimes()
@@ -310,5 +314,6 @@ func prepareClient(ctrl *gomock.Controller) *client {
 		policyCache:              sync.Map{},
 		globalConjMatchFlowCache: map[string]*conjMatchFlowContext{},
 	}
+	c.cookieAllocator = cookie.NewAllocator(0)
 	return c
 }

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"sync"
 
+	"github.com/vmware-tanzu/antrea/pkg/agent/openflow/cookie"
 	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
 )
 
@@ -72,10 +73,6 @@ func (rt regType) reg() string {
 	return fmt.Sprintf("reg%d", rt)
 }
 
-func i2h(data int64) string {
-	return fmt.Sprintf("0x%x", data)
-}
-
 const (
 	// marksReg stores traffic-source mark and pod-found mark.
 	// traffic-source resides in [0..15], pod-found resides in [16].
@@ -86,6 +83,9 @@ const (
 
 	portFoundMark = 0x1
 	gatewayCTMark = 0x20
+
+	// round number key in externalIDs
+	roundNumKey = "roundNum"
 )
 
 var (
@@ -107,6 +107,7 @@ type flowCategoryCache struct {
 }
 
 type client struct {
+	cookieAllocator                           cookie.Allocator
 	bridge                                    binding.Bridge
 	pipeline                                  map[binding.TableIDType]binding.Table
 	nodeFlowCache, podFlowCache, serviceCache *flowCategoryCache // cache for corresponding deletions
@@ -146,37 +147,40 @@ func (c *client) defaultFlows() (flows []binding.Flow) {
 		default:
 			flowBuilder = flowBuilder.Action().Drop()
 		}
-		flows = append(flows, flowBuilder.Done())
+		flows = append(flows, flowBuilder.Cookie(c.cookieAllocator.Request(cookie.Default).Raw()).Done())
 	}
 	return flows
 }
 
 // tunnelClassifierFlow generates the flow to mark traffic comes from the tunnelOFPort.
-func (c *client) tunnelClassifierFlow(tunnelOFPort uint32) binding.Flow {
+func (c *client) tunnelClassifierFlow(tunnelOFPort uint32, category cookie.Category) binding.Flow {
 	return c.pipeline[classifierTable].BuildFlow(priorityNormal).
 		MatchInPort(tunnelOFPort).
 		Action().LoadRegRange(int(marksReg), markTrafficFromTunnel, binding.Range{0, 15}).
 		Action().ResubmitToTable(conntrackTable).
+		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
 
 // gatewayClassifierFlow generates the flow to mark traffic comes from the gatewayOFPort.
-func (c *client) gatewayClassifierFlow(gatewayOFPort uint32) binding.Flow {
+func (c *client) gatewayClassifierFlow(gatewayOFPort uint32, category cookie.Category) binding.Flow {
 	classifierTable := c.pipeline[classifierTable]
 	return classifierTable.BuildFlow(priorityNormal).
 		MatchInPort(gatewayOFPort).
 		Action().LoadRegRange(int(marksReg), markTrafficFromGateway, binding.Range{0, 15}).
 		Action().ResubmitToTable(classifierTable.GetNext()).
+		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
 
 // podClassifierFlow generates the flow to mark traffic comes from the podOFPort.
-func (c *client) podClassifierFlow(podOFPort uint32) binding.Flow {
+func (c *client) podClassifierFlow(podOFPort uint32, category cookie.Category) binding.Flow {
 	classifierTable := c.pipeline[classifierTable]
 	return classifierTable.BuildFlow(priorityLow).
 		MatchInPort(podOFPort).
 		Action().LoadRegRange(int(marksReg), markTrafficFromLocal, binding.Range{0, 15}).
 		Action().ResubmitToTable(classifierTable.GetNext()).
+		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
 
@@ -186,10 +190,11 @@ func (c *client) podClassifierFlow(podOFPort uint32) binding.Flow {
 // 3) Cache src MAC if traffic comes from the host gateway and rewrite the dst MAC on traffic replied from Pod to the
 // cached MAC.
 // 4) Drop all invalid traffic.
-func (c *client) connectionTrackFlows() (flows []binding.Flow) {
+func (c *client) connectionTrackFlows(category cookie.Category) (flows []binding.Flow) {
 	connectionTrackTable := c.pipeline[conntrackTable]
 	baseConnectionTrackFlow := connectionTrackTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 		Action().CT(false, connectionTrackTable.GetNext(), ctZone).CTDone().
+		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 	flows = append(flows, baseConnectionTrackFlow)
 
@@ -199,6 +204,7 @@ func (c *client) connectionTrackFlows() (flows []binding.Flow) {
 		MatchCTMark(gatewayCTMark).
 		MatchCTStateNew(false).MatchCTStateTrk(true).
 		Action().ResubmitToTable(connectionTrackStateTable.GetNext()).
+		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 	flows = append(flows, gatewayReplyFlow)
 
@@ -206,6 +212,7 @@ func (c *client) connectionTrackFlows() (flows []binding.Flow) {
 		MatchRegRange(int(marksReg), markTrafficFromGateway, binding.Range{0, 15}).
 		MatchCTStateNew(true).MatchCTStateTrk(true).
 		Action().CT(true, connectionTrackStateTable.GetNext(), ctZone).LoadToMark(gatewayCTMark).MoveToLabel(binding.NxmFieldSrcMAC, &binding.Range{0, 47}, &binding.Range{0, 47}).CTDone().
+		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 	flows = append(flows, gatewaySendFlow)
 
@@ -214,18 +221,21 @@ func (c *client) connectionTrackFlows() (flows []binding.Flow) {
 		MatchCTStateNew(false).MatchCTStateTrk(true).
 		Action().MoveRange(binding.NxmFieldCtLabel, binding.NxmFieldDstMAC, binding.Range{0, 47}, binding.Range{0, 47}).
 		Action().ResubmitToTable(connectionTrackStateTable.GetNext()).
+		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 	flows = append(flows, podReplyGatewayFlow)
 
 	nonGatewaySendFlow := connectionTrackStateTable.BuildFlow(priorityLow).MatchProtocol(binding.ProtocolIP).
 		MatchCTStateNew(true).MatchCTStateTrk(true).
 		Action().CT(true, connectionTrackStateTable.GetNext(), ctZone).CTDone().
+		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 	flows = append(flows, nonGatewaySendFlow)
 
 	invCTFlow := connectionTrackStateTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 		MatchCTStateNew(true).MatchCTStateInv(true).
 		Action().Drop().
+		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 	flows = append(flows, invCTFlow)
 
@@ -233,26 +243,28 @@ func (c *client) connectionTrackFlows() (flows []binding.Flow) {
 }
 
 // l2ForwardCalcFlow generates the flow that matches dst MAC and loads ofPort to reg.
-func (c *client) l2ForwardCalcFlow(dstMAC net.HardwareAddr, ofPort uint32) binding.Flow {
+func (c *client) l2ForwardCalcFlow(dstMAC net.HardwareAddr, ofPort uint32, category cookie.Category) binding.Flow {
 	l2FwdCalcTable := c.pipeline[l2ForwardingCalcTable]
 	return l2FwdCalcTable.BuildFlow(priorityNormal).
 		MatchDstMAC(dstMAC).
 		Action().LoadRegRange(int(portCacheReg), ofPort, ofPortRegRange).
 		Action().LoadRegRange(int(marksReg), portFoundMark, ofPortMarkRange).
 		Action().ResubmitToTable(l2FwdCalcTable.GetNext()).
+		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
 
 // l2ForwardOutputFlow generates the flow that outputs packets to OVS port after L2 forwarding calculation.
-func (c *client) l2ForwardOutputFlow() binding.Flow {
+func (c *client) l2ForwardOutputFlow(category cookie.Category) binding.Flow {
 	return c.pipeline[l2ForwardingOutTable].BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 		MatchRegRange(int(marksReg), portFoundMark, ofPortMarkRange).
 		Action().OutputRegRange(int(portCacheReg), ofPortRegRange).
+		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
 
 // l3FlowsToPod generates the flow to rewrite MAC if the packet is received from tunnel port and destined for local Pods.
-func (c *client) l3FlowsToPod(localGatewayMAC net.HardwareAddr, podInterfaceIP net.IP, podInterfaceMAC net.HardwareAddr) binding.Flow {
+func (c *client) l3FlowsToPod(localGatewayMAC net.HardwareAddr, podInterfaceIP net.IP, podInterfaceMAC net.HardwareAddr, category cookie.Category) binding.Flow {
 	l3FwdTable := c.pipeline[l3ForwardingTable]
 	// Rewrite src MAC to local gateway MAC, and rewrite dst MAC to pod MAC
 	return l3FwdTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
@@ -262,21 +274,23 @@ func (c *client) l3FlowsToPod(localGatewayMAC net.HardwareAddr, podInterfaceIP n
 		Action().SetDstMAC(podInterfaceMAC).
 		Action().DecTTL().
 		Action().ResubmitToTable(l3FwdTable.GetNext()).
+		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
 
 // l3ToGatewayFlow generates flow that rewrites MAC of the packet received from tunnel port and destined to local gateway.
-func (c *client) l3ToGatewayFlow(localGatewayIP net.IP, localGatewayMAC net.HardwareAddr) binding.Flow {
+func (c *client) l3ToGatewayFlow(localGatewayIP net.IP, localGatewayMAC net.HardwareAddr, category cookie.Category) binding.Flow {
 	l3FwdTable := c.pipeline[l3ForwardingTable]
 	return l3FwdTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 		MatchDstIP(localGatewayIP).
 		Action().SetDstMAC(localGatewayMAC).
 		Action().ResubmitToTable(l3FwdTable.GetNext()).
+		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
 
 // l3FwdFlowToRemote generates the L3 forward flow on source node to support traffic to remote pods/gateway.
-func (c *client) l3FwdFlowToRemote(localGatewayMAC net.HardwareAddr, peerSubnet net.IPNet, tunnelPeer net.IP) binding.Flow {
+func (c *client) l3FwdFlowToRemote(localGatewayMAC net.HardwareAddr, peerSubnet net.IPNet, tunnelPeer net.IP, category cookie.Category) binding.Flow {
 	l3FwdTable := c.pipeline[l3ForwardingTable]
 	// Rewrite src MAC to local gateway MAC and rewrite dst MAC to virtual MAC
 	return l3FwdTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
@@ -286,12 +300,13 @@ func (c *client) l3FwdFlowToRemote(localGatewayMAC net.HardwareAddr, peerSubnet 
 		Action().SetDstMAC(globalVirtualMAC).
 		Action().SetTunnelDst(tunnelPeer).
 		Action().ResubmitToTable(l3FwdTable.GetNext()).
+		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
 
 // arpResponderFlow generates the ARP responder flow entry that replies request comes from local gateway for peer
 // gateway MAC.
-func (c *client) arpResponderFlow(peerGatewayIP net.IP) binding.Flow {
+func (c *client) arpResponderFlow(peerGatewayIP net.IP, category cookie.Category) binding.Flow {
 	return c.pipeline[arpResponderTable].BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolARP).
 		MatchARPOp(1).
 		MatchARPTpa(peerGatewayIP).
@@ -303,12 +318,13 @@ func (c *client) arpResponderFlow(peerGatewayIP net.IP) binding.Flow {
 		Action().Move(binding.NxmFieldARPSpa, binding.NxmFieldARPTpa).
 		Action().SetARPSpa(peerGatewayIP).
 		Action().OutputInPort().
+		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
 
 // podIPSpoofGuardFlow generates the flow to check IP traffic sent out from local pod. Traffic from host gateway interface
 // will not be checked, since it might be pod to service traffic or host namespace traffic.
-func (c *client) podIPSpoofGuardFlow(ifIP net.IP, ifMAC net.HardwareAddr, ifOFPort uint32) binding.Flow {
+func (c *client) podIPSpoofGuardFlow(ifIP net.IP, ifMAC net.HardwareAddr, ifOFPort uint32, category cookie.Category) binding.Flow {
 	ipPipeline := c.pipeline
 	ipSpoofGuardTable := ipPipeline[spoofGuardTable]
 	return ipSpoofGuardTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
@@ -316,49 +332,56 @@ func (c *client) podIPSpoofGuardFlow(ifIP net.IP, ifMAC net.HardwareAddr, ifOFPo
 		MatchSrcMAC(ifMAC).
 		MatchSrcIP(ifIP).
 		Action().ResubmitToTable(ipSpoofGuardTable.GetNext()).
+		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
 
 // gatewayARPSpoofGuardFlow generates the flow to skip ARP UP check on packets sent out from the local gateway interface.
-func (c *client) gatewayARPSpoofGuardFlow(gatewayOFPort uint32) binding.Flow {
+func (c *client) gatewayARPSpoofGuardFlow(gatewayOFPort uint32, category cookie.Category) binding.Flow {
 	return c.pipeline[spoofGuardTable].BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolARP).
 		MatchInPort(gatewayOFPort).
 		Action().ResubmitToTable(arpResponderTable).
+		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
 
 // arpSpoofGuardFlow generates the flow to check ARP traffic sent out from local pods interfaces.
-func (c *client) arpSpoofGuardFlow(ifIP net.IP, ifMAC net.HardwareAddr, ifOFPort uint32) binding.Flow {
+func (c *client) arpSpoofGuardFlow(ifIP net.IP, ifMAC net.HardwareAddr, ifOFPort uint32, category cookie.Category) binding.Flow {
 	return c.pipeline[spoofGuardTable].BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolARP).
 		MatchInPort(ifOFPort).
 		MatchARPSha(ifMAC).
 		MatchARPSpa(ifIP).
 		Action().ResubmitToTable(arpResponderTable).
+		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
 
 // gatewayIPSpoofGuardFlow generates the flow to skip spoof guard checking for traffic sent from gateway interface.
-func (c *client) gatewayIPSpoofGuardFlow(gatewayOFPort uint32) binding.Flow {
+func (c *client) gatewayIPSpoofGuardFlow(gatewayOFPort uint32, category cookie.Category) binding.Flow {
 	ipPipeline := c.pipeline
 	ipSpoofGuardTable := ipPipeline[spoofGuardTable]
 	return ipSpoofGuardTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 		MatchInPort(gatewayOFPort).
 		Action().ResubmitToTable(ipSpoofGuardTable.GetNext()).
+		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
 
 // serviceCIDRDNATFlow generates flows to match dst IP in service CIDR and output to host gateway interface directly.
-func (c *client) serviceCIDRDNATFlow(serviceCIDR *net.IPNet, gatewayOFPort uint32) binding.Flow {
+func (c *client) serviceCIDRDNATFlow(serviceCIDR *net.IPNet, gatewayOFPort uint32, category cookie.Category) binding.Flow {
 	return c.pipeline[dnatTable].BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 		MatchDstIPNet(*serviceCIDR).
 		Action().Output(int(gatewayOFPort)).
+		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
 
 // arpNormalFlow generates the flow to response arp in normal way if no flow in arpResponderTable is matched.
-func (c *client) arpNormalFlow() binding.Flow {
+func (c *client) arpNormalFlow(category cookie.Category) binding.Flow {
 	return c.pipeline[arpResponderTable].BuildFlow(priorityLow).MatchProtocol(binding.ProtocolARP).
-		Action().Normal().Done()
+		Action().Normal().
+		Cookie(c.cookieAllocator.Request(category).Raw()).
+		Done()
 }
 
 // conjunctionActionFlow generates the flow to resubmit to a specific table if policyRuleConjunction ID is matched. Priority of
@@ -366,7 +389,9 @@ func (c *client) arpNormalFlow() binding.Flow {
 func (c *client) conjunctionActionFlow(conjunctionID uint32, tableID binding.TableIDType, nextTable binding.TableIDType) binding.Flow {
 	return c.pipeline[tableID].BuildFlow(priorityLow).MatchProtocol(binding.ProtocolIP).
 		MatchConjID(conjunctionID).
-		Action().ResubmitToTable(nextTable).Done()
+		Action().ResubmitToTable(nextTable).
+		Cookie(c.cookieAllocator.Request(cookie.Policy).Raw()).
+		Done()
 }
 
 func (c *client) Disconnect() error {
@@ -378,21 +403,25 @@ func newFlowCategoryCache() *flowCategoryCache {
 }
 
 // establishedConnectionFlows generates flows to ensure established connections skip the NetworkPolicy rules.
-func (c *client) establishedConnectionFlows() (flows []binding.Flow) {
+func (c *client) establishedConnectionFlows(category cookie.Category) (flows []binding.Flow) {
 	// egressDropTable checks the source address of packets, and drops packets sent from the AppliedToGroup but not
 	// matching the NetworkPolicy rules. Packets in the established connections need not to be checked with the
 	// egressRuleTable or the egressDropTable.
 	egressDropTable := c.pipeline[egressDefaultTable]
 	egressEstFlow := c.pipeline[egressRuleTable].BuildFlow(priorityHigh).MatchProtocol(binding.ProtocolIP).
 		MatchCTStateNew(false).MatchCTStateEst(true).
-		Action().ResubmitToTable(egressDropTable.GetNext()).Done()
+		Action().ResubmitToTable(egressDropTable.GetNext()).
+		Cookie(c.cookieAllocator.Request(category).Raw()).
+		Done()
 	// ingressDropTable checks the destination address of packets, and drops packets sent to the AppliedToGroup but not
 	// matching the NetworkPolicy rules. Packets in the established connections need not to be checked with the
 	// ingressRuleTable or ingressDropTable.
 	ingressDropTable := c.pipeline[ingressDefaultTable]
 	ingressEstFlow := c.pipeline[ingressRuleTable].BuildFlow(priorityHigh).MatchProtocol(binding.ProtocolIP).
 		MatchCTStateNew(false).MatchCTStateEst(true).
-		Action().ResubmitToTable(ingressDropTable.GetNext()).Done()
+		Action().ResubmitToTable(ingressDropTable.GetNext()).
+		Cookie(c.cookieAllocator.Request(category).Raw()).
+		Done()
 	return []binding.Flow{egressEstFlow, ingressEstFlow}
 }
 
@@ -425,7 +454,9 @@ func (c *client) addFlowMatch(fb binding.FlowBuilder, matchType int, matchValue 
 func (c *client) conjunctionExceptionFlow(conjunctionID uint32, tableID binding.TableIDType, nextTable binding.TableIDType, matchKey int, matchValue interface{}) binding.Flow {
 	fb := c.pipeline[tableID].BuildFlow(priorityNormal).MatchConjID(conjunctionID)
 	return c.addFlowMatch(fb, matchKey, matchValue).
-		Action().ResubmitToTable(nextTable).Done()
+		Action().ResubmitToTable(nextTable).
+		Cookie(c.cookieAllocator.Request(cookie.Policy).Raw()).
+		Done()
 }
 
 // conjunctiveMatchFlow generates the flow to set conjunctive actions if the match condition is matched.
@@ -435,27 +466,31 @@ func (c *client) conjunctiveMatchFlow(tableID binding.TableIDType, matchKey int,
 	for _, act := range actions {
 		fb.Action().Conjunction(act.conjID, act.clauseID, act.nClause)
 	}
-	return fb.Done()
+	return fb.Cookie(c.cookieAllocator.Request(cookie.Policy).Raw()).Done()
 }
 
 // defaultDropFlow generates the flow to drop packets if the match condition is matched.
 func (c *client) defaultDropFlow(tableID binding.TableIDType, matchKey int, matchValue interface{}) binding.Flow {
 	fb := c.pipeline[tableID].BuildFlow(priorityNormal)
 	return c.addFlowMatch(fb, matchKey, matchValue).
-		Action().Drop().Done()
+		Action().Drop().
+		Cookie(c.cookieAllocator.Request(cookie.Default).Raw()).
+		Done()
 }
 
 // localProbeFlow generates the flow to resubmit packets to l2ForwardingOutTable. The packets are sent from Node to probe the liveness/readiness of local Pods.
-func (c *client) localProbeFlow(localGatewayIP net.IP) binding.Flow {
+func (c *client) localProbeFlow(localGatewayIP net.IP, category cookie.Category) binding.Flow {
 	return c.pipeline[ingressRuleTable].BuildFlow(priorityHigh).
 		MatchProtocol(binding.ProtocolIP).
 		MatchSrcIP(localGatewayIP).
-		Action().ResubmitToTable(l2ForwardingOutTable).Done()
+		Action().ResubmitToTable(l2ForwardingOutTable).
+		Cookie(c.cookieAllocator.Request(category).Raw()).
+		Done()
 }
 
 // NewClient is the constructor of the Client interface.
-func NewClient(bridgeName string) Client {
-	bridge := binding.NewOFBridge(bridgeName)
+func NewClient(brName string) Client {
+	bridge := binding.NewOFBridge(brName)
 	c := &client{
 		bridge: bridge,
 		pipeline: map[binding.TableIDType]binding.Table{

--- a/pkg/agent/openflow/testing/mock_client.go
+++ b/pkg/agent/openflow/testing/mock_client.go
@@ -23,6 +23,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/vmware-tanzu/antrea/pkg/agent/types"
 	openflow "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
+	ovsconfig "github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
 	net "net"
 	reflect "reflect"
 )
@@ -107,17 +108,17 @@ func (mr *MockClientMockRecorder) GetFlowTableStatus() *gomock.Call {
 }
 
 // Initialize mocks base method
-func (m *MockClient) Initialize() error {
+func (m *MockClient) Initialize(arg0 ovsconfig.OVSBridgeClient) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Initialize")
+	ret := m.ctrl.Call(m, "Initialize", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Initialize indicates an expected call of Initialize
-func (mr *MockClientMockRecorder) Initialize() *gomock.Call {
+func (mr *MockClientMockRecorder) Initialize(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockClient)(nil).Initialize))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockClient)(nil).Initialize), arg0)
 }
 
 // InstallClusterServiceCIDRFlows mocks base method


### PR DESCRIPTION
- Add a cookie allocator to mark flow by cookie id
- Add function `roundNum` to `pipeline.go` to read roundNum from ovsdb
- Updated related mocks and unit tests

Signed-off-by: Weiqiang TANG <weiqiangt@vmware.com>